### PR TITLE
Jetty 12

### DIFF
--- a/javalin-ssl/pom.xml
+++ b/javalin-ssl/pom.xml
@@ -74,6 +74,10 @@
             <artifactId>jetty-http2-client-transport</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>jetty-http2-server</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-alpn-conscrypt-server</artifactId>
         </dependency>

--- a/javalin-testtools/pom.xml
+++ b/javalin-testtools/pom.xml
@@ -66,6 +66,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+            <artifactId>jetty-ee10-websocket-jetty-server</artifactId>
+            <version>${jetty.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>

--- a/javalin/src/test/java/io/javalin/TestBeforeAfterMatched.kt
+++ b/javalin/src/test/java/io/javalin/TestBeforeAfterMatched.kt
@@ -14,7 +14,6 @@ import io.javalin.testing.TestUtil
 import kong.unirest.HttpResponse
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.jetty.server.AliasCheck
-import org.eclipse.jetty.server.handler.ContextHandler
 import org.junit.jupiter.api.Test
 
 class TestBeforeAfterMatched {
@@ -241,6 +240,7 @@ class TestBeforeAfterMatched {
         config.staticFiles.add("/public/assets", Location.CLASSPATH)
         config.staticFiles.add("src/test/external/", Location.EXTERNAL)
     }) { app, http ->
+        //FIXME afterMatched does not work with jetty resource hnalder
         app.beforeMatched { it.header("X-Matched-Before", "abc") }
         app.afterMatched { it.header("X-Matched-After", "xyz") }
         fun assertHeaders(path: String) {

--- a/javalin/src/test/java/io/javalin/TestMaxRequestSize.kt
+++ b/javalin/src/test/java/io/javalin/TestMaxRequestSize.kt
@@ -13,6 +13,7 @@ class TestMaxRequestSize {
     fun `max request size is set by default`() = TestUtil.test { app, http ->
         app.post("/") { it.result(it.body()) }
         assertThat(http.post("/").body(ByteArray(1_000_000)).asString().httpCode()).isEqualTo(OK)
+//fixme: We are getting SocketException: Connection reset, Unirest  is not getting HTTP response?
         assertThat(http.post("/").body(ByteArray(1_000_001)).asString().httpCode()).isEqualTo(CONTENT_TOO_LARGE)
     }
 

--- a/javalin/src/test/java/io/javalin/testing/TestUtil.java
+++ b/javalin/src/test/java/io/javalin/testing/TestUtil.java
@@ -13,6 +13,7 @@ import io.javalin.util.JavalinLogger;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import kong.unirest.HttpMethod;
+import kong.unirest.Unirest;
 
 public class TestUtil {
 
@@ -40,8 +41,8 @@ public class TestUtil {
             HttpUtil http = new HttpUtil(app.port());
             userCode.accept(app, http);
             app.delete("/x-test-cookie-cleaner", ctx -> ctx.cookieMap().keySet().forEach(ctx::removeCookie));
-            // FIXME: cookie are not removed
             http.call(HttpMethod.DELETE, "/x-test-cookie-cleaner");
+            Unirest.shutDown();
             app.stop();
         });
         app.unsafeConfig().appData(TestLogsKey, result.logs);

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 
         <!-- DEPENDENCIES -->
         <annotations.version>25.0.0</annotations.version>
-        <jetty.version>12.0.18</jetty.version>
+        <jetty.version>12.0.19</jetty.version>
         <jetty.jakarta-api>5.0.2</jetty.jakarta-api>
         <jackson.version>2.18.0</jackson.version>
         <jackson.databind.version>2.18.0</jackson.databind.version>


### PR DESCRIPTION
* added few missing dependencies
* cleaned the cookies between tests

I will continue investigating the rest of the topics later.

I also realised that afterMatched does not work as expected after migrating to jetty12 because of its static resource handlers that bypass servlet filters and listeners. Will dig into that as well